### PR TITLE
Add ability to run custom commands job

### DIFF
--- a/helm/minio/templates/_helper_custom_command.txt
+++ b/helm/minio/templates/_helper_custom_command.txt
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -e ; # Have script exit in the event of a failed command.
+
+{{- if .Values.configPathmc }}
+MC_CONFIG_DIR="{{ .Values.configPathmc }}"
+MC="/usr/bin/mc --insecure --config-dir ${MC_CONFIG_DIR}"
+{{- else }}
+MC="/usr/bin/mc --insecure"
+{{- end }}
+
+# connectToMinio
+# Use a check-sleep-check loop to wait for MinIO service to be available
+connectToMinio() {
+  SCHEME=$1
+  ATTEMPTS=0 ; LIMIT=29 ; # Allow 30 attempts
+  set -e ; # fail if we can't read the keys.
+  ACCESS=$(cat /config/rootUser) ; SECRET=$(cat /config/rootPassword) ;
+  set +e ; # The connections to minio are allowed to fail.
+  echo "Connecting to MinIO server: $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT" ;
+  MC_COMMAND="${MC} config host add myminio $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT $ACCESS $SECRET" ;
+  $MC_COMMAND ;
+  STATUS=$? ;
+  until [ $STATUS = 0 ]
+  do
+    ATTEMPTS=`expr $ATTEMPTS + 1` ;
+    echo \"Failed attempts: $ATTEMPTS\" ;
+    if [ $ATTEMPTS -gt $LIMIT ]; then
+      exit 1 ;
+    fi ;
+    sleep 2 ; # 1 second intervals between attempts
+    $MC_COMMAND ;
+    STATUS=$? ;
+  done ;
+  set -e ; # reset `e` as active
+  return 0
+}
+
+# runCommand ($@)
+# Run custom mc command
+runCommand() {
+  ${MC} "$@"
+  return $?
+}
+
+# Try connecting to MinIO instance
+{{- if .Values.tls.enabled }}
+scheme=https
+{{- else }}
+scheme=http
+{{- end }}
+connectToMinio $scheme
+
+{{ if .Values.customCommands }}
+# Run custom commands
+{{- range .Values.customCommands }}
+runCommand {{ .command }}
+{{- end }}
+{{- end }}

--- a/helm/minio/templates/configmap.yaml
+++ b/helm/minio/templates/configmap.yaml
@@ -13,3 +13,5 @@ data:
 {{ include (print $.Template.BasePath "/_helper_create_bucket.txt") . | indent 4 }}
   add-user: |-
 {{ include (print $.Template.BasePath "/_helper_create_user.txt") . | indent 4 }}
+  custom-command: |-
+{{ include (print $.Template.BasePath "/_helper_custom_command.txt") . | indent 4 }}

--- a/helm/minio/templates/post-install-custom-command.yaml
+++ b/helm/minio/templates/post-install-custom-command.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.customCommands }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "minio.fullname" . }}-custom-command-job
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "minio.name" . }}-custom-command-job
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+{{- with .Values.customCommandJob.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "minio.name" . }}-job
+        release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+{{- if .Values.customCommandJob.podAnnotations }}
+      annotations:
+{{ toYaml .Values.customCommandJob.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+      restartPolicy: OnFailure
+{{- include "minio.imagePullSecrets" . | indent 6 }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.customCommandJob.nodeSelector | indent 8 }}
+{{- end }}
+{{- with .Values.customCommandJob.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.customCommandJob.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- if .Values.customCommandJob.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.customCommandJob.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.customCommandJob.securityContext.runAsGroup }}
+        fsGroup: {{ .Values.customCommandJob.securityContext.fsGroup }}
+{{- end }}
+      volumes:
+        - name: minio-configuration
+          projected:
+            sources:
+            - configMap:
+                name: {{ template "minio.fullname" . }}
+            - secret:
+                name: {{ template "minio.secretName" . }}
+        {{- if .Values.tls.enabled }}
+        - name: cert-secret-volume-mc
+          secret:
+            secretName: {{ .Values.tls.certSecret }}
+            items:
+            - key: {{ .Values.tls.publicCrt }}
+              path: CAs/public.crt
+        {{ end }}
+      containers:
+      - name: minio-mc
+        image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"
+        imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
+        command: ["/bin/sh", "/config/custom-command"]
+        env:
+          - name: MINIO_ENDPOINT
+            value: {{ template "minio.fullname" . }}
+          - name: MINIO_PORT
+            value: {{ .Values.service.port | quote }}
+        volumeMounts:
+          - name: minio-configuration
+            mountPath: /config
+          {{- if .Values.tls.enabled }}
+          - name: cert-secret-volume-mc
+            mountPath: {{ .Values.configPathmc }}certs
+          {{ end }}
+        resources:
+{{ toYaml .Values.customCommandJob.resources | indent 10 }}
+{{- end }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -308,6 +308,27 @@ makeBucketJob:
   tolerations: []
   affinity: {}
 
+## List of command to run after minio install
+## NOTE: the mc command TARGET is always "myminio"
+customCommands:
+  # - command: "admin policy set myminio consoleAdmin group='cn=ops,cn=groups,dc=example,dc=com'"
+
+## Additional Annotations for the Kubernetes Job customCommandJob
+customCommandJob:
+  podAnnotations:
+  annotations:
+  securityContext:
+    enabled: false
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+  resources:
+    requests:
+      memory: 128Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
 ## Use this field to add environment variables relevant to MinIO server. These fields will be passed on to MinIO container(s)
 ## when Chart is deployed
 environment:


### PR DESCRIPTION
## Description
Add ability to run custom mc commands while applying Helm chart.

## Motivation and Context
Making the Helm chart a bit more IaaC. Currently, it's impossible to apply for example a policy to an LDAP group automatically and doing this manually is not my cup of tea.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
